### PR TITLE
Add audit logging for authorization operations

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -10,6 +10,7 @@
     <suppress checks="JavadocMethod" files=".*/test/java/.*/BenchmarkRunner\.java"/>
 
     <!-- FIXME will remove after cleaning the code -->
-    <suppress checks="CyclomaticComplexity" files="AivenAclAuthorizer.java"/>
-    <suppress checks="NPathComplexity" files="AivenAclAuthorizer.java"/>
+    <suppress checks="CyclomaticComplexity" files="AivenAclAuthorizer.java" />
+    <suppress checks="ClassFanOutComplexity" files="AivenAclAuthorizer.java" />
+    <suppress checks="NPathComplexity" files="AivenAclAuthorizer.java" />
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -115,15 +115,9 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.25</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -153,6 +147,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth;
+
+import java.io.File;
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import io.aiven.kafka.auth.audit.Auditor;
+import io.aiven.kafka.auth.audit.NoAuditor;
+
+public final class AivenAclAuthorizerConfig extends AbstractConfig {
+    private static final String CONFIGURATION_CONF = "aiven.acl.authorizer.configuration";
+    private static final String AUDITOR_CLASS_NAME_CONF = "aiven.acl.authorizer.auditor.class.name";
+
+    public AivenAclAuthorizerConfig(final Map<?, ?> originals) {
+        super(configDef(), originals);
+    }
+
+    public static ConfigDef configDef() {
+        return new ConfigDef()
+            .define(
+                CONFIGURATION_CONF,
+                ConfigDef.Type.STRING,
+                ConfigDef.NO_DEFAULT_VALUE,
+                ConfigDef.Importance.HIGH,
+                "The path to the configuration file"
+            ).define(
+                AUDITOR_CLASS_NAME_CONF,
+                ConfigDef.Type.CLASS,
+                NoAuditor.class,
+                ConfigDef.Importance.MEDIUM,
+                "The auditor class fully qualified name"
+            );
+    }
+
+    public final File getConfigFile() {
+        return new File(getString(CONFIGURATION_CONF));
+    }
+
+    public final Auditor getAuditor() {
+        return getConfiguredInstance(AUDITOR_CLASS_NAME_CONF, Auditor.class);
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/Auditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/Auditor.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import kafka.network.RequestChannel.Session;
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class Auditor implements Configurable {
+
+    private final Logger logger;
+
+    protected Map<AuditKey, UserActivity> auditStorage = new HashMap<>();
+
+    private final Lock auditLock = new ReentrantLock();
+
+    private final ScheduledExecutorService auditScheduler =
+        Executors.newScheduledThreadPool(1);
+
+    public Auditor() {
+        this.logger = LoggerFactory.getLogger("aiven.auditor.logger");
+    }
+
+    // visible for test
+    protected Auditor(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        final AuditorConfig auditorConfig = new AuditorConfig(configs);
+        auditScheduler.scheduleAtFixedRate(
+            this::dump,
+            auditorConfig.getAggregationPeriodInSeconds(),
+            auditorConfig.getAggregationPeriodInSeconds(),
+            TimeUnit.SECONDS
+        );
+    }
+
+    public void addActivity(final Session session,
+                            final Operation operation,
+                            final Resource resource,
+                            final Boolean hasAccess) {
+
+        final AuditKey auditKey = new AuditKey(session.principal(), session.clientAddress());
+        auditLock.lock();
+        try {
+            auditStorage.compute(auditKey, (key, userActivity) -> {
+                if (Objects.isNull(userActivity)) {
+                    return onUserActivity(new UserActivity(), operation, resource, hasAccess);
+                } else {
+                    return onUserActivity(userActivity, operation, resource, hasAccess);
+                }
+            });
+        } finally {
+            auditLock.unlock();
+        }
+    }
+
+    public void stop() {
+        auditScheduler.shutdownNow();
+        dump();
+    }
+
+    protected void dump() {
+        final Map<AuditKey, UserActivity> auditStorageDump;
+        auditLock.lock();
+        try {
+            auditStorageDump = auditStorage;
+            auditStorage = new HashMap<>();
+        } finally {
+            auditLock.unlock();
+        }
+        auditStorageDump.forEach((key, userActivity) -> logger.info(auditMessage(key, userActivity)));
+    }
+
+    private String auditMessage(final AuditKey key, final UserActivity userActivity) {
+        final StringBuilder auditMessage = new StringBuilder(key.principal.toString());
+        auditMessage
+            .append(" (").append(key.sourceIp).append(")")
+            .append(" was active since ")
+            .append(userActivity.activeSince.format(DateTimeFormatter.ISO_INSTANT));
+        if (userActivity.hasOperations()) {
+            auditMessage.append(": ")
+                .append(
+                    userActivity
+                        .operations
+                        .stream()
+                        .map(this::userOperationMessage)
+                        .collect(Collectors.joining(", "))
+                );
+        }
+        return auditMessage.toString();
+    }
+
+    private String userOperationMessage(final UserOperation op) {
+        return (op.hasAccess ? "Allow" : "Deny")
+            + " " + op.operation.name() + " on "
+            + op.resource.resourceType() + ":"
+            + op.resource.name();
+    }
+
+    protected abstract UserActivity onUserActivity(final UserActivity userActivity,
+                                                   final Operation operation,
+                                                   final Resource resource,
+                                                   final Boolean hasAccess);
+
+    protected static class AuditKey {
+
+        public final KafkaPrincipal principal;
+
+        public final InetAddress sourceIp;
+
+        protected AuditKey(final KafkaPrincipal principal, final InetAddress sourceIp) {
+            this.principal = principal;
+            this.sourceIp = sourceIp;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AuditKey)) {
+                return false;
+            }
+            final AuditKey auditKey = (AuditKey) o;
+            return Objects.equals(principal, auditKey.principal)
+                && Objects.equals(sourceIp, auditKey.sourceIp);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(principal, sourceIp);
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class AuditorConfig extends AbstractConfig {
+
+    static final String AGGREGATION_PERIOD_CONF = "aiven.acl.authorizer.auditor.aggregation.period";
+
+    public AuditorConfig(final Map<?, ?> originals) {
+        super(configDef(), originals);
+    }
+
+    public static ConfigDef configDef() {
+        return new ConfigDef()
+            .define(
+                AGGREGATION_PERIOD_CONF,
+                ConfigDef.Type.LONG,
+                ConfigDef.NO_DEFAULT_VALUE,
+                ConfigDef.Range.atLeast(1),
+                ConfigDef.Importance.HIGH,
+                "The auditor aggregation period in seconds."
+            );
+    }
+
+    public long getAggregationPeriodInSeconds() {
+        return getLong(AGGREGATION_PERIOD_CONF);
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/NoAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/NoAuditor.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.util.Map;
+
+import kafka.network.RequestChannel;
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+
+public class NoAuditor extends Auditor {
+
+    public NoAuditor() {
+        super();
+    }
+
+    @Override
+    protected UserActivity onUserActivity(final UserActivity userActivity,
+                                          final Operation operation,
+                                          final Resource resource,
+                                          final Boolean hasAccess) {
+        return userActivity;
+    }
+
+    @Override
+    public void addActivity(final RequestChannel.Session session,
+                            final Operation operation,
+                            final Resource resource,
+                            final Boolean hasAccess) {
+    }
+
+    @Override
+    public void configure(final Map<String, ?> map) {
+    }
+
+    @Override
+    public void stop() {
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+class UserActivity {
+
+    public final ZonedDateTime activeSince;
+
+    public final Set<UserOperation> operations;
+
+    public UserActivity() {
+        this.activeSince = ZonedDateTime.now();
+        this.operations = new HashSet<>();
+    }
+
+    public void addOperation(final UserOperation userOperation) {
+        operations.add(userOperation);
+    }
+
+    public boolean hasOperations() {
+        return !operations.isEmpty();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UserActivity)) {
+            return false;
+        }
+        final UserActivity that = (UserActivity) o;
+        return Objects.equals(activeSince, that.activeSince)
+            && Objects.equals(operations, that.operations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(activeSince, operations);
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivityAuditor.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+import org.slf4j.Logger;
+
+public class UserActivityAuditor extends Auditor {
+
+    public UserActivityAuditor() {
+    }
+
+    protected UserActivityAuditor(final Logger logger) {
+        super(logger);
+    }
+
+    @Override
+    protected UserActivity onUserActivity(final UserActivity userActivity,
+                                          final Operation operation,
+                                          final Resource resource,
+                                          final Boolean hasAccess) {
+        return userActivity;
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.util.Objects;
+
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+
+public class UserOperation {
+
+    public final Operation operation;
+
+    public final Resource resource;
+
+    public final boolean hasAccess;
+
+    public UserOperation(final Operation operation,
+                         final Resource resource,
+                         final boolean hasAccess) {
+        this.operation = operation;
+        this.resource = resource;
+        this.hasAccess = hasAccess;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UserOperation)) {
+            return false;
+        }
+        final UserOperation that = (UserOperation) o;
+        return hasAccess == that.hasAccess
+            && Objects.equals(operation, that.operation)
+            && Objects.equals(resource, that.resource);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, resource, hasAccess);
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+import org.slf4j.Logger;
+
+public class UserOperationsActivityAuditor extends Auditor {
+
+    public UserOperationsActivityAuditor() {
+    }
+
+    protected UserOperationsActivityAuditor(final Logger logger) {
+        super(logger);
+    }
+
+    @Override
+    protected UserActivity onUserActivity(final UserActivity userActivity,
+                                          final Operation operation,
+                                          final Resource resource,
+                                          final Boolean hasAccess) {
+        userActivity.addOperation(new UserOperation(operation, resource, hasAccess));
+        return userActivity;
+    }
+
+}

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
+
+import io.aiven.kafka.auth.audit.NoAuditor;
+import io.aiven.kafka.auth.audit.UserActivityAuditor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AivenAclAuthorizerConfigTest {
+
+    @Test
+    void correctMinimalConfig() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("aiven.acl.authorizer.configuration", "/test");
+
+        final AivenAclAuthorizerConfig config = new AivenAclAuthorizerConfig(properties);
+        assertEquals("/test", config.getConfigFile().getAbsolutePath());
+        assertEquals(NoAuditor.class, config.getAuditor().getClass());
+    }
+
+    @Test
+    void correctFullConfig() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("aiven.acl.authorizer.configuration", "/test");
+        properties.put("aiven.acl.authorizer.auditor.class.name", UserActivityAuditor.class.getName());
+        properties.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
+
+        final AivenAclAuthorizerConfig config = new AivenAclAuthorizerConfig(properties);
+        assertEquals("/test", config.getConfigFile().getAbsolutePath());
+        assertEquals(UserActivityAuditor.class, config.getAuditor().getClass());
+    }
+
+    @Test
+    void missingConfigPath() {
+        final Map<String, String> properties = new HashMap<>();
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new AivenAclAuthorizerConfig(properties));
+        assertEquals(
+            "Missing required configuration \"aiven.acl.authorizer.configuration\" which has no default value.",
+            t.getMessage()
+        );
+    }
+
+    @Test
+    void incorrectAuditorClass() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("aiven.acl.authorizer.configuration", "/test");
+        properties.put("aiven.acl.authorizer.auditor.class.name", ArrayList.class.getName());
+
+        final AivenAclAuthorizerConfig config = new AivenAclAuthorizerConfig(properties);
+        final Throwable t = assertThrows(
+            KafkaException.class,
+            config::getAuditor);
+        assertEquals(
+            "java.util.ArrayList is not an instance of io.aiven.kafka.auth.audit.Auditor",
+            t.getMessage()
+        );
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/AuditorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/AuditorConfigTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AuditorConfigTest {
+    @Test
+    void correctMinimalConfig() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
+
+        final AuditorConfig config = new AuditorConfig(properties);
+        assertEquals(123, config.getAggregationPeriodInSeconds());
+    }
+
+    @Test
+    void missingAggregationPeriod() {
+        final Map<String, String> properties = new HashMap<>();
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new AuditorConfig(properties));
+        assertEquals(
+            "Missing required configuration \"aiven.acl.authorizer.auditor.aggregation.period\" "
+                + "which has no default value.",
+            t.getMessage()
+        );
+    }
+
+    @Test
+    void incorrectAggregationPeriod() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("aiven.acl.authorizer.auditor.aggregation.period", "-1");
+
+        final Throwable t = assertThrows(
+            ConfigException.class,
+            () -> new AuditorConfig(properties));
+        assertEquals(
+            "Invalid value -1 for configuration aiven.acl.authorizer.auditor.aggregation.period: "
+                + "Value must be at least 1",
+            t.getMessage()
+        );
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/UserActivityAuditorTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/UserActivityAuditorTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import com.google.common.collect.ImmutableMap;
+import kafka.network.RequestChannel.Session;
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+import kafka.security.auth.ResourceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserActivityAuditorTest {
+
+    @Mock
+    private Logger logger;
+
+    private Session session;
+    private Operation operation;
+    private Resource resource;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        final KafkaPrincipal principal = new KafkaPrincipal("PRINCIPAL_TYPE", "PRINCIPAL_NAME");
+        session = new Session(principal, InetAddress.getLocalHost());
+        resource =
+            new Resource(
+                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.CLUSTER),
+                "resource",
+                PatternType.LITERAL
+            );
+        operation = Operation.fromJava(AclOperation.ALTER);
+    }
+
+    @Test
+    public void shouldDumpMessagesWhenStop() {
+        final Auditor auditor = spy(createAuditor());
+        auditor.addActivity(session, operation, resource, false);
+        auditor.stop();
+        verify(auditor).dump();
+    }
+
+    @Test
+    public void shouldBuildRightLogMessage() throws UnknownHostException {
+        final Auditor auditor = createAuditor();
+
+        auditor.addActivity(session, operation, resource, false);
+        assertEquals(1, auditor.auditStorage.size());
+        auditor.dump();
+        assertEquals(0, auditor.auditStorage.size());
+
+        final ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        verify(logger).info(argument.capture());
+
+        final String expectedPrefix = String.format(
+            "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since ",
+            InetAddress.getLocalHost()
+        );
+        assertTrue(argument.getValue().startsWith(expectedPrefix));
+
+        final String timestampStr = argument.getValue().substring(expectedPrefix.length());
+        final Instant instant = Instant.parse(timestampStr);
+        final long diffSeconds = Math.abs(ChronoUnit.SECONDS.between(instant, Instant.now()));
+        assertTrue(diffSeconds < 3);
+    }
+
+    private UserActivityAuditor createAuditor() {
+        final UserActivityAuditor auditor = new UserActivityAuditor(logger);
+        auditor.configure(ImmutableMap.of(AuditorConfig.AGGREGATION_PERIOD_CONF, Long.MAX_VALUE));
+        return auditor;
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditorTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditorTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import com.google.common.collect.ImmutableMap;
+import kafka.network.RequestChannel.Session;
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+import kafka.security.auth.ResourceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserOperationsActivityAuditorTest {
+
+    @Mock
+    private Logger logger;
+
+    private Session session;
+
+    private KafkaPrincipal principal;
+
+    private Operation operation;
+
+    private Resource resource;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        principal = new KafkaPrincipal("PRINCIPAL_TYPE", "PRINCIPAL_NAME");
+        session = new Session(principal, InetAddress.getLocalHost());
+
+        operation = Operation.fromJava(AclOperation.ALL);
+        resource =
+            new Resource(
+                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.CLUSTER),
+                "RESOURCE_NAME",
+                PatternType.LITERAL
+            );
+    }
+
+    @Test
+    public void shouldDumpMessagesWhenStop() {
+        final Auditor auditor = spy(createAuditor());
+        auditor.addActivity(session, operation, resource, false);
+        auditor.stop();
+        verify(auditor).dump();
+    }
+
+    @Test
+    public void shouldAddUserActivityAndOperation() throws UnknownHostException {
+        final UserOperationsActivityAuditor auditor = createAuditor();
+
+        auditor.addActivity(session, operation, resource, false);
+        assertEquals(1, auditor.auditStorage.size());
+        assertEquals(
+            1,
+            auditor.auditStorage.get(
+                new Auditor.AuditKey(principal, InetAddress.getLocalHost())
+            ).operations.size()
+        );
+        auditor.dump();
+        assertEquals(0, auditor.auditStorage.size());
+    }
+
+    @Test
+    void shouldAggregateOperationsForSameUser() throws Exception {
+
+        final Session anotherSession =
+            new Session(principal, InetAddress.getByName("127.0.0.2"));
+
+        final UserOperationsActivityAuditor auditor = createAuditor();
+
+        auditor.addActivity(session, operation, resource, false);
+        auditor.addActivity(session, operation, resource, true);
+        auditor.addActivity(anotherSession, operation, resource, true);
+        assertEquals(2, auditor.auditStorage.size());
+        assertEquals(
+            2,
+            auditor.auditStorage.get(
+                new Auditor.AuditKey(
+                    session.principal(),
+                    session.clientAddress())
+            ).operations.size()
+        );
+        assertEquals(
+            1,
+            auditor.auditStorage.get(
+                new Auditor.AuditKey(
+                    anotherSession.principal(),
+                    anotherSession.clientAddress())
+            ).operations.size()
+        );
+        auditor.dump();
+        assertEquals(0, auditor.auditStorage.size());
+    }
+
+    @Test
+    public void shouldBuildRightLogMessage() throws Exception {
+        final UserOperationsActivityAuditor auditor = createAuditor();
+        final Operation anotherOperation = Operation.fromJava(AclOperation.ALTER);
+        final Resource anotherResource = new Resource(
+            ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
+            "ANOTHER_RESOURCE_NAME",
+            PatternType.LITERAL
+        );
+
+        final ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
+        auditor.addActivity(session, operation, resource, false);
+        auditor.addActivity(session, anotherOperation, anotherResource, true);
+        auditor.dump();
+
+        verify(logger).info(logCaptor.capture());
+
+        final String expectedPrefix = String.format(
+            "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since ",
+            InetAddress.getLocalHost()
+        );
+
+        assertTrue(logCaptor.getValue().startsWith(expectedPrefix));
+        final String timestampStr =
+            logCaptor.getValue()
+                .substring(
+                    expectedPrefix.length(),
+                    logCaptor.getValue().indexOf(": ")
+                );
+        final Instant instant = Instant.parse(timestampStr);
+        final long diffSeconds = Math.abs(ChronoUnit.SECONDS.between(instant, Instant.now()));
+        assertTrue(diffSeconds < 3);
+
+        final Set<String> loggedOperations = Arrays.stream(logCaptor.getValue()
+            .substring(logCaptor.getValue().indexOf(": ") + 1)
+            .split(",")).map(String::trim).collect(Collectors.toSet());
+
+
+        final String[] expectedOperations = new String[]{
+            "Deny All on Cluster:RESOURCE_NAME",
+            "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME"
+        };
+
+        assertThat(loggedOperations, containsInAnyOrder(expectedOperations));
+    }
+
+    private UserOperationsActivityAuditor createAuditor() {
+        final UserOperationsActivityAuditor auditor =
+            new UserOperationsActivityAuditor(logger);
+        auditor.configure(ImmutableMap.of(AuditorConfig.AGGREGATION_PERIOD_CONF, 10L));
+        return auditor;
+    }
+
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n


### PR DESCRIPTION
Two types of audit aggregation have been added:
- `io.aiven.kafka.auth.audit.UserActivityAuditor` - aggregate user activity
- `io.aiven.kafka.auth.audit.UserOperationsActivityAuditor` - aggregate user activity and unique combination of operations.