### PR TITLE
Kafka audit log aggregation

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizer.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizer.java
@@ -26,7 +26,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
-import io.aiven.kafka.auth.audit.Auditor;
+import io.aiven.kafka.auth.audit.AuditorAPI;
 import io.aiven.kafka.auth.json.AivenAcl;
 import io.aiven.kafka.auth.json.reader.AclJsonReader;
 import io.aiven.kafka.auth.json.reader.JsonReader;
@@ -50,7 +50,7 @@ public class AivenAclAuthorizer implements Authorizer {
     private List<AivenAcl> aclEntries;
     private Map<String, Boolean> verdictCache;
     private JsonReader<AivenAcl> jsonReader;
-    private Auditor auditor;
+    private AuditorAPI auditor;
     private boolean logDenials;
 
     public AivenAclAuthorizer() {

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
-import io.aiven.kafka.auth.audit.Auditor;
+import io.aiven.kafka.auth.audit.AuditorAPI;
 import io.aiven.kafka.auth.audit.NoAuditor;
 
 public final class AivenAclAuthorizerConfig extends AbstractConfig {
@@ -61,8 +61,8 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
         return new File(getString(CONFIGURATION_CONF));
     }
 
-    public final Auditor getAuditor() {
-        return getConfiguredInstance(AUDITOR_CLASS_NAME_CONF, Auditor.class);
+    public final AuditorAPI getAuditor() {
+        return getConfiguredInstance(AUDITOR_CLASS_NAME_CONF, AuditorAPI.class);
     }
 
     public final boolean logDenials() {

--- a/src/main/java/io/aiven/kafka/auth/audit/Auditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/Auditor.java
@@ -34,8 +34,8 @@ import kafka.security.auth.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.AGGREGATION_GROUPING_PRINCIPAL;
-import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.PRINCIPAL;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.PRINCIPAL_AND_SOURCE_IP;
 
 public abstract class Auditor implements AuditorAPI {
 
@@ -74,9 +74,9 @@ public abstract class Auditor implements AuditorAPI {
 
     private AuditorDumpFormatter createFormatter(final AuditorConfig auditorConfig) {
         final String grouping = auditorConfig.getAggregationGrouping();
-        if (AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP.getConfigValue().equals(grouping)) {
+        if (PRINCIPAL_AND_SOURCE_IP.getConfigValue().equals(grouping)) {
             return new PrincipalAndIpFormatter();
-        } else if (AGGREGATION_GROUPING_PRINCIPAL.getConfigValue().equals(grouping)) {
+        } else if (PRINCIPAL.getConfigValue().equals(grouping)) {
             return new PrincipalFormatter();
         } else {
             throw new RuntimeException("Not implemented");

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorAPI.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Aiven Oy https://aiven.io
+ * Copyright 2021 Aiven Oy https://aiven.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,25 @@
 
 package io.aiven.kafka.auth.audit;
 
-import java.util.Map;
+import org.apache.kafka.common.Configurable;
 
 import kafka.network.RequestChannel;
 import kafka.security.auth.Operation;
 import kafka.security.auth.Resource;
 
-/**
- * A no-op {@link AuditorAPI}.
- */
-public class NoAuditor implements AuditorAPI {
+public interface AuditorAPI extends Configurable {
+    /**
+     * A callback to audit a user activity.
+     *
+     * @param session the associated session
+     * @param operation the associated operation
+     * @param resource the associated resource
+     * @param hasAccess whether access was granted
+     */
+    void addActivity(RequestChannel.Session session,
+                     Operation operation,
+                     Resource resource,
+                     boolean hasAccess);
 
-    public NoAuditor() {
-        super();
-    }
-
-    @Override
-    public void addActivity(final RequestChannel.Session session,
-                            final Operation operation,
-                            final Resource resource,
-                            final boolean hasAccess) {
-    }
-
-    @Override
-    public void configure(final Map<String, ?> map) {
-    }
-
-    @Override
-    public void stop() {
-    }
+    void stop();
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
-import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.AGGREGATION_GROUPING_PRINCIPAL;
-import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.PRINCIPAL;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.PRINCIPAL_AND_SOURCE_IP;
 
 public class AuditorConfig extends AbstractConfig {
 
@@ -30,8 +30,8 @@ public class AuditorConfig extends AbstractConfig {
     static final String AGGREGATION_GROUPING_CONF = "aiven.acl.authorizer.auditor.aggregation.grouping";
 
     public enum AggregationGrouping {
-        AGGREGATION_GROUPING_PRINCIPAL("Principal"),
-        AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP("PrincipalAndSourceIp");
+        PRINCIPAL("Principal"),
+        PRINCIPAL_AND_SOURCE_IP("PrincipalAndSourceIp");
 
         private final String configValue;
 
@@ -60,9 +60,9 @@ public class AuditorConfig extends AbstractConfig {
             ).define(
                 AGGREGATION_GROUPING_CONF,
                 ConfigDef.Type.STRING,
-                AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP.getConfigValue(),
-                ConfigDef.ValidString.in(AGGREGATION_GROUPING_PRINCIPAL.getConfigValue(),
-                        AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP.getConfigValue()),
+                PRINCIPAL_AND_SOURCE_IP.getConfigValue(),
+                ConfigDef.ValidString.in(PRINCIPAL.getConfigValue(),
+                        PRINCIPAL_AND_SOURCE_IP.getConfigValue()),
                 ConfigDef.Importance.HIGH,
                 "The auditor aggregation grouping key."
             );

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
@@ -21,9 +21,28 @@ import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.AGGREGATION_GROUPING_PRINCIPAL;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP;
+
 public class AuditorConfig extends AbstractConfig {
 
     static final String AGGREGATION_PERIOD_CONF = "aiven.acl.authorizer.auditor.aggregation.period";
+    static final String AGGREGATION_GROUPING_CONF = "aiven.acl.authorizer.auditor.aggregation.grouping";
+
+    public enum AggregationGrouping {
+        AGGREGATION_GROUPING_PRINCIPAL("Principal"),
+        AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP("PrincipalAndSourceIp");
+
+        private final String configValue;
+
+        AggregationGrouping(final String configValue) {
+            this.configValue = configValue;
+        }
+
+        public String getConfigValue() {
+            return configValue;
+        }
+    }
 
     public AuditorConfig(final Map<?, ?> originals) {
         super(configDef(), originals);
@@ -38,10 +57,22 @@ public class AuditorConfig extends AbstractConfig {
                 ConfigDef.Range.atLeast(1),
                 ConfigDef.Importance.HIGH,
                 "The auditor aggregation period in seconds."
+            ).define(
+                AGGREGATION_GROUPING_CONF,
+                ConfigDef.Type.STRING,
+                AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP.getConfigValue(),
+                ConfigDef.ValidString.in(AGGREGATION_GROUPING_PRINCIPAL.getConfigValue(),
+                        AGGREGATION_GROUPING_PRINCIPAL_AND_SOURCE_IP.getConfigValue()),
+                ConfigDef.Importance.HIGH,
+                "The auditor aggregation grouping key."
             );
     }
 
     public long getAggregationPeriodInSeconds() {
         return getLong(AGGREGATION_PERIOD_CONF);
+    }
+
+    public String getAggregationGrouping() {
+        return getString(AGGREGATION_GROUPING_CONF);
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorDumpFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorDumpFormatter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Formatter for audit dump.
+ */
+public interface AuditorDumpFormatter {
+    /**
+     * Converts the given {@code dump} as log entries.
+     *
+     * @param dump the dump
+     * @return the log entries
+     */
+    List<String> format(Map<Auditor.AuditKey, UserActivity> dump);
+
+    static DateTimeFormatter dateFormatter() {
+        return DateTimeFormatter.ISO_INSTANT;
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * An {@link AuditorDumpFormatter} that creates an entry for each IP
+ * of each principal.
+ */
+public class PrincipalAndIpFormatter implements AuditorDumpFormatter {
+    PrincipalAndIpFormatter() {
+    }
+
+    @Override
+    public List<String> format(final Map<Auditor.AuditKey, UserActivity> dump) {
+        return dump.entrySet().stream()
+                .map(e -> auditMessagePrincipalAndSourceIp(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private String auditMessagePrincipalAndSourceIp(final Auditor.AuditKey key, final UserActivity userActivity) {
+        final StringBuilder auditMessage = new StringBuilder(key.principal.toString());
+        auditMessage
+                .append(" (").append(key.sourceIp).append(")")
+                .append(" was active since ")
+                .append(userActivity.activeSince.format(AuditorDumpFormatter.dateFormatter()));
+        if (userActivity.hasOperations()) {
+            auditMessage.append(": ")
+                    .append(userActivity
+                            .operations
+                            .stream()
+                            .map(this::userOperationMessage)
+                            .collect(Collectors.joining(", ")));
+        }
+        return auditMessage.toString();
+    }
+
+    private String userOperationMessage(final UserOperation op) {
+        return (op.hasAccess ? "Allow" : "Deny")
+                + " " + op.operation.name() + " on "
+                + op.resource.resourceType() + ":"
+                + op.resource.name();
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/PrincipalFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/PrincipalFormatter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+/**
+ * An {@link AuditorDumpFormatter} that creates one entry per principal,
+ * having info of each IP address in that entry.
+ */
+public class PrincipalFormatter implements AuditorDumpFormatter {
+    @Override
+    public List<String> format(final Map<Auditor.AuditKey, UserActivity> dump) {
+        return dump.keySet().stream()
+                .map(k -> k.principal)
+                .sorted(Comparator.comparing(KafkaPrincipal::toString))
+                .distinct()
+                .map(principal -> {
+                    final Map<Auditor.AuditKey, UserActivity> principalActivities = dump.entrySet().stream()
+                            .filter(e -> e.getKey().principal.equals(principal))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+
+                    return auditMessagePrincipal(principal, principalActivities);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private String auditMessagePrincipal(final KafkaPrincipal principal,
+                                         final Map<Auditor.AuditKey, UserActivity> principalActivities) {
+        final ZonedDateTime earliest = principalActivities.values().stream()
+                .map(ua -> ua.activeSince)
+                .sorted()
+                .findFirst()
+                .get();
+
+        final StringBuilder auditMessage = new StringBuilder(principal.toString());
+        auditMessage
+                .append(" was active since ")
+                .append(earliest.format(AuditorDumpFormatter.dateFormatter()))
+                .append(".");
+
+        final String allActivities = principalActivities.entrySet().stream()
+                .map(e -> {
+                    final InetAddress sourceIp = e.getKey().sourceIp;
+                    final UserActivity userActivity = e.getValue();
+                    final List<String> operations = userActivity.operations.stream().map(op ->
+                            (op.hasAccess ? "Allow" : "Deny")
+                                    + " " + op.operation.name() + " on "
+                                    + op.resource.resourceType() + ":"
+                                    + op.resource.name()
+                    ).collect(Collectors.toList());
+
+                    final StringBuilder sb = new StringBuilder();
+                    sb.append(sourceIp.toString());
+                    if (!operations.isEmpty()) {
+                        sb.append(": ");
+                        sb.append(String.join(", ", operations));
+                    }
+                    return sb.toString();
+                })
+                .collect(Collectors.joining(", "));
+        if (!allActivities.isBlank()) {
+            auditMessage.append(" ");
+            auditMessage.append(allActivities);
+        }
+
+        return auditMessage.toString();
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
@@ -17,23 +17,31 @@
 package io.aiven.kafka.auth.audit;
 
 import java.time.ZonedDateTime;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 class UserActivity {
-
     public final ZonedDateTime activeSince;
 
-    public final Set<UserOperation> operations;
+    /**
+     * Ordered in the order the order the operations are added.
+     */
+    public final List<UserOperation> operations;
 
     public UserActivity() {
-        this.activeSince = ZonedDateTime.now();
-        this.operations = new HashSet<>();
+        this(ZonedDateTime.now());
+    }
+
+    public UserActivity(final ZonedDateTime activeSince) {
+        this.activeSince = activeSince;
+        this.operations = new ArrayList<>();
     }
 
     public void addOperation(final UserOperation userOperation) {
-        operations.add(userOperation);
+        if (!operations.contains(userOperation)) {
+            operations.add(userOperation);
+        }
     }
 
     public boolean hasOperations() {

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
@@ -47,8 +47,8 @@ public class UserOperation {
         }
         final UserOperation that = (UserOperation) o;
         return hasAccess == that.hasAccess
-            && Objects.equals(operation, that.operation)
-            && Objects.equals(resource, that.resource);
+                && Objects.equals(operation, that.operation)
+                && Objects.equals(resource, that.resource);
     }
 
     @Override

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
@@ -84,7 +84,7 @@ class AivenAclAuthorizerConfigTest {
             KafkaException.class,
             config::getAuditor);
         assertEquals(
-            "java.util.ArrayList is not an instance of io.aiven.kafka.auth.audit.Auditor",
+            "java.util.ArrayList is not an instance of io.aiven.kafka.auth.audit.AuditorAPI",
             t.getMessage()
         );
     }

--- a/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import kafka.network.RequestChannel;
+import kafka.security.auth.Operation;
+import kafka.security.auth.Resource;
+import kafka.security.auth.ResourceType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FormatterTestBase {
+    protected RequestChannel.Session session;
+    protected Operation operation;
+    protected Resource resource;
+    protected AuditorDumpFormatter formatter;
+    private Operation anotherOperation;
+    private Resource anotherResource;
+    private RequestChannel.Session anotherSession;
+    protected InetAddress anotherInetAddress;
+
+    void setUp() throws Exception {
+        final KafkaPrincipal principal = new KafkaPrincipal("PRINCIPAL_TYPE", "PRINCIPAL_NAME");
+        session = new RequestChannel.Session(principal, InetAddress.getLocalHost());
+        anotherInetAddress = InetAddress.getByName("192.168.0.1");
+        anotherSession = new RequestChannel.Session(principal, anotherInetAddress);
+        resource =
+                new Resource(
+                        ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.CLUSTER),
+                        "resource",
+                        PatternType.LITERAL
+                );
+        operation = Operation.fromJava(AclOperation.ALTER);
+
+        anotherOperation = Operation.fromJava(AclOperation.ALTER);
+        anotherResource = new Resource(
+                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
+                "ANOTHER_RESOURCE_NAME",
+                PatternType.LITERAL
+        );
+    }
+
+    protected void zeroOperations(final ZonedDateTime now, final String expected) {
+        final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
+        final UserActivity userActivity = new UserActivity(now);
+        dump.put(Auditor.AuditKey.fromSession(session), userActivity);
+
+        formatAndAssert(dump, expected);
+    }
+
+    protected void twoOperations(final ZonedDateTime now, final String expected) {
+        final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
+        final UserActivity userActivity = new UserActivity(now);
+        userActivity.operations.add(new UserOperation(operation, resource, false));
+        userActivity.operations.add(new UserOperation(anotherOperation, anotherResource, true));
+        dump.put(Auditor.AuditKey.fromSession(session), userActivity);
+
+        formatAndAssert(dump, expected);
+    }
+
+    protected void twoOperationsTwoIpAddresses(final ZonedDateTime now, final String... expected) {
+        final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
+        final UserActivity userActivity = new UserActivity(now);
+        userActivity.operations.add(new UserOperation(operation, resource, false));
+        dump.put(Auditor.AuditKey.fromSession(session), userActivity);
+
+        final UserActivity anotherUserActivity = new UserActivity(now);
+        anotherUserActivity.operations.add(new UserOperation(anotherOperation, anotherResource, true));
+        dump.put(Auditor.AuditKey.fromSession(anotherSession), anotherUserActivity);
+
+        formatAndAssert(dump, expected);
+    }
+
+    private void formatAndAssert(final Map<Auditor.AuditKey, UserActivity> dump, final String... expected) {
+        final List<String> entries = formatter.format(dump);
+        assertEquals(expected.length, entries.size());
+        assertEquals(Arrays.asList(expected), entries);
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link PrincipalAndIpFormatter}.
+ */
+public class PrincipalAndIpFormatterTest extends FormatterTestBase {
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        formatter = new PrincipalAndIpFormatter();
+    }
+
+    @Test
+    public void shouldBuildRightLogMessageZeroOperations() throws Exception {
+        final ZonedDateTime now = ZonedDateTime.now();
+        final String expected = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s",
+                InetAddress.getLocalHost(),
+                now.format(AuditorDumpFormatter.dateFormatter())
+        );
+        zeroOperations(now, expected);
+    }
+
+    @Test
+    public void shouldBuildRightLogMessageTwoOperations() throws Exception {
+        final ZonedDateTime now = ZonedDateTime.now();
+        final String expected = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: "
+                        + "Deny Alter on Cluster:resource, "
+                        + "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                InetAddress.getLocalHost(),
+                now.format(AuditorDumpFormatter.dateFormatter())
+        );
+
+        twoOperations(now, expected);
+    }
+
+    @Test
+    public void shouldBuildRightLogMessageTwoOperationsTwoIps() throws Exception {
+        final ZonedDateTime now = ZonedDateTime.now();
+        final String expected1 = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: Deny Alter on Cluster:resource",
+                InetAddress.getLocalHost(),
+                now.format(AuditorDumpFormatter.dateFormatter())
+        );
+        final String expected2 = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: "
+                        + "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                anotherInetAddress,
+                now.format(AuditorDumpFormatter.dateFormatter())
+        );
+
+        twoOperationsTwoIpAddresses(now, expected1, expected2);
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalFormatterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.audit;
+
+import java.net.InetAddress;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link PrincipalFormatter}.
+ */
+public class PrincipalFormatterTest extends FormatterTestBase {
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        formatter = new PrincipalFormatter();
+    }
+
+    @Test
+    public void shouldBuildRightLogMessageZeroOperations() throws Exception {
+        final ZonedDateTime now = ZonedDateTime.now();
+        final String expected = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME was active since %s. %s",
+                now.format(AuditorDumpFormatter.dateFormatter()),
+                InetAddress.getLocalHost()
+        );
+        zeroOperations(now, expected);
+    }
+
+    @Test
+    public void shouldBuildRightLogMessageTwoOperations() throws Exception {
+        final ZonedDateTime now = ZonedDateTime.now();
+        final String expected = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME was active since %s. %s: "
+                        + "Deny Alter on Cluster:resource, Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                now.format(AuditorDumpFormatter.dateFormatter()),
+                InetAddress.getLocalHost()
+        );
+
+        twoOperations(now, expected);
+    }
+
+    @Test
+    public void shouldBuildRightLogMessageTwoOperationsTwoIps() throws Exception {
+        final ZonedDateTime now = ZonedDateTime.now();
+        final String expected = String.format(
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME was active since %s. "
+                        + "%s: Deny Alter on Cluster:resource, "
+                        + "%s: Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                now.format(AuditorDumpFormatter.dateFormatter()),
+                InetAddress.getLocalHost(),
+                anotherInetAddress
+        );
+
+        twoOperationsTwoIpAddresses(now, expected);
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/UserActivityAuditorTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/UserActivityAuditorTest.java
@@ -68,7 +68,7 @@ class UserActivityAuditorTest {
 
     @Test
     public void shouldDumpMessagesWhenStop() {
-        final Auditor auditor = spy(createAuditor());
+        final UserActivityAuditor auditor = spy(createAuditor());
         auditor.addActivity(session, operation, resource, false);
         auditor.stop();
         verify(auditor).dump();
@@ -87,8 +87,8 @@ class UserActivityAuditorTest {
         verify(logger).info(argument.capture());
 
         final String expectedPrefix = String.format(
-            "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since ",
-            InetAddress.getLocalHost()
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since ",
+                InetAddress.getLocalHost()
         );
         assertTrue(argument.getValue().startsWith(expectedPrefix));
 

--- a/src/test/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditorTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditorTest.java
@@ -78,7 +78,7 @@ class UserOperationsActivityAuditorTest {
 
     @Test
     public void shouldDumpMessagesWhenStop() {
-        final Auditor auditor = spy(createAuditor());
+        final UserOperationsActivityAuditor auditor = spy(createAuditor());
         auditor.addActivity(session, operation, resource, false);
         auditor.stop();
         verify(auditor).dump();
@@ -137,9 +137,9 @@ class UserOperationsActivityAuditorTest {
         final UserOperationsActivityAuditor auditor = createAuditor();
         final Operation anotherOperation = Operation.fromJava(AclOperation.ALTER);
         final Resource anotherResource = new Resource(
-            ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
-            "ANOTHER_RESOURCE_NAME",
-            PatternType.LITERAL
+                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
+                "ANOTHER_RESOURCE_NAME",
+                PatternType.LITERAL
         );
 
         final ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
@@ -150,27 +150,27 @@ class UserOperationsActivityAuditorTest {
         verify(logger).info(logCaptor.capture());
 
         final String expectedPrefix = String.format(
-            "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since ",
-            InetAddress.getLocalHost()
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since ",
+                InetAddress.getLocalHost()
         );
 
         assertTrue(logCaptor.getValue().startsWith(expectedPrefix));
         final String timestampStr =
-            logCaptor.getValue()
-                .substring(
-                    expectedPrefix.length(),
-                    logCaptor.getValue().indexOf(": ")
-                );
+                logCaptor.getValue()
+                        .substring(
+                                expectedPrefix.length(),
+                                logCaptor.getValue().indexOf(": ")
+                        );
         final Instant instant = Instant.parse(timestampStr);
         final long diffSeconds = Math.abs(ChronoUnit.SECONDS.between(instant, Instant.now()));
         assertTrue(diffSeconds < 3);
 
         final Set<String> loggedOperations = Arrays.stream(logCaptor.getValue()
-            .substring(logCaptor.getValue().indexOf(": ") + 1)
-            .split(",")).map(String::trim).collect(Collectors.toSet());
+                .substring(logCaptor.getValue().indexOf(": ") + 1)
+                .split(",")).map(String::trim).collect(Collectors.toSet());
 
 
-        final String[] expectedOperations = new String[]{
+        final String[] expectedOperations = new String[] {
             "Deny All on Cluster:RESOURCE_NAME",
             "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME"
         };


### PR DESCRIPTION
Added a new configuration parameter `aiven.acl.authorizer.auditor.aggregation.grouping` with values `PrincipalAndSourceIp` (default) and `Principal`. If omitted or `PrincipalAndSourceIp` no change in behaviour.

With the value `Principal` the authorization audit messages are aggregated do that each principal creates one log entry, in contracts to `PrincipalAndSourceIp` each principal-ip address-tuple creates a separate log entry. In the single entry format, all the IP addresses are listed with the operations originating from that IP - the same infomation is written but on a single row.

The idea is that using this new parameter value there will considerably less log entries in certain cases.

Same technical changes:
* Extracted interface `AuditorAPI`. The no op version doesn't need to extend `Auditor`
* Refactored the audit log message formatting out of `Auditor` for the code be more OOP and for testability
* Added tests