### PR TITLE
Code refactoring

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorConfig.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
-import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.PRINCIPAL;
-import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.PRINCIPAL_AND_SOURCE_IP;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.USER;
+import static io.aiven.kafka.auth.audit.AuditorConfig.AggregationGrouping.USER_AND_IP;
 
 public class AuditorConfig extends AbstractConfig {
 
@@ -30,8 +30,8 @@ public class AuditorConfig extends AbstractConfig {
     static final String AGGREGATION_GROUPING_CONF = "aiven.acl.authorizer.auditor.aggregation.grouping";
 
     public enum AggregationGrouping {
-        PRINCIPAL("principal"),
-        PRINCIPAL_AND_SOURCE_IP("principal_and_source_ip");
+        USER("user"),
+        USER_AND_IP("user_and_ip");
 
         private final String configValue;
 
@@ -42,6 +42,16 @@ public class AuditorConfig extends AbstractConfig {
         public String getConfigValue() {
             return configValue;
         }
+
+        public static AggregationGrouping fromConfigValue(final String configValue) {
+            for (final var ag : values()) {
+                if (ag.configValue.equals(configValue)) {
+                    return ag;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported aggregation grouping: " + configValue);
+        }
+
     }
 
     public AuditorConfig(final Map<?, ?> originals) {
@@ -60,9 +70,9 @@ public class AuditorConfig extends AbstractConfig {
             ).define(
                 AGGREGATION_GROUPING_CONF,
                 ConfigDef.Type.STRING,
-                PRINCIPAL_AND_SOURCE_IP.getConfigValue(),
-                ConfigDef.ValidString.in(PRINCIPAL.getConfigValue(),
-                        PRINCIPAL_AND_SOURCE_IP.getConfigValue()),
+                USER_AND_IP.getConfigValue(),
+                ConfigDef.ValidString.in(USER.getConfigValue(),
+                        USER_AND_IP.getConfigValue()),
                 ConfigDef.Importance.HIGH,
                 "The auditor aggregation grouping key."
             );
@@ -72,7 +82,7 @@ public class AuditorConfig extends AbstractConfig {
         return getLong(AGGREGATION_PERIOD_CONF);
     }
 
-    public String getAggregationGrouping() {
-        return getString(AGGREGATION_GROUPING_CONF);
+    public AggregationGrouping getAggregationGrouping() {
+        return AggregationGrouping.fromConfigValue(getString(AGGREGATION_GROUPING_CONF));
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorDumpFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorDumpFormatter.java
@@ -35,4 +35,12 @@ public interface AuditorDumpFormatter {
     static DateTimeFormatter dateFormatter() {
         return DateTimeFormatter.ISO_INSTANT;
     }
+
+    default String formatUserOperation(final UserOperation userOperation) {
+        return (userOperation.hasAccess ? "Allow" : "Deny")
+                + " " + userOperation.operation.name() + " on "
+                + userOperation.resource.resourceType() + ":"
+                + userOperation.resource.name();
+    }
+
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
@@ -16,37 +16,28 @@
 
 package io.aiven.kafka.auth.audit;
 
+import java.net.InetAddress;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiFunction;
 
-class UserActivity {
+abstract class UserActivity {
+
     public final ZonedDateTime activeSince;
 
-    /**
-     * Ordered in the order the order the operations are added.
-     */
-    public final List<UserOperation> operations;
-
-    public UserActivity() {
+    protected UserActivity() {
         this(ZonedDateTime.now());
     }
 
-    public UserActivity(final ZonedDateTime activeSince) {
+    protected UserActivity(final ZonedDateTime activeSince) {
         this.activeSince = activeSince;
-        this.operations = new ArrayList<>();
     }
 
-    public void addOperation(final UserOperation userOperation) {
-        if (!operations.contains(userOperation)) {
-            operations.add(userOperation);
-        }
-    }
-
-    public boolean hasOperations() {
-        return !operations.isEmpty();
-    }
+    abstract void addOperation(final UserOperation userOperation);
 
     @Override
     public boolean equals(final Object o) {
@@ -57,12 +48,59 @@ class UserActivity {
             return false;
         }
         final UserActivity that = (UserActivity) o;
-        return Objects.equals(activeSince, that.activeSince)
-            && Objects.equals(operations, that.operations);
+        return Objects.equals(activeSince, that.activeSince);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(activeSince, operations);
+        return Objects.hash(activeSince);
     }
+
+    static final class UserActivityOperations extends UserActivity {
+
+        public UserActivityOperations() {
+            super();
+        }
+
+        public UserActivityOperations(final ZonedDateTime activeSince) {
+            super(activeSince);
+        }
+
+        /**
+         * Ordered in the order the order the operations are added.
+         */
+        public final Set<UserOperation> operations = new LinkedHashSet<>();
+
+        @Override
+        void addOperation(final UserOperation userOperation) {
+            operations.add(userOperation);
+        }
+
+    }
+
+    static final class UserActivityOperationsGropedByIP extends UserActivity {
+
+        public UserActivityOperationsGropedByIP() {
+            super();
+        }
+
+        public UserActivityOperationsGropedByIP(final ZonedDateTime activeSince) {
+            super(activeSince);
+        }
+
+        public final Map<InetAddress, Set<UserOperation>> operations = new LinkedHashMap<>();
+
+        @Override
+        void addOperation(final UserOperation userOperation) {
+            final BiFunction<InetAddress, Set<UserOperation>, Set<UserOperation>> resolveUserOperations = (ip, o) -> {
+                final var ops =
+                        Objects.isNull(o) ? new LinkedHashSet<UserOperation>() : o;
+                ops.add(userOperation);
+                return ops;
+            };
+            operations.compute(userOperation.sourceIp, resolveUserOperations::apply);
+        }
+
+    }
+
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
@@ -16,12 +16,15 @@
 
 package io.aiven.kafka.auth.audit;
 
+import java.net.InetAddress;
 import java.util.Objects;
 
 import kafka.security.auth.Operation;
 import kafka.security.auth.Resource;
 
 public class UserOperation {
+
+    public final InetAddress sourceIp;
 
     public final Operation operation;
 
@@ -32,6 +35,14 @@ public class UserOperation {
     public UserOperation(final Operation operation,
                          final Resource resource,
                          final boolean hasAccess) {
+        this(null, operation, resource, hasAccess);
+    }
+
+    public UserOperation(final InetAddress sourceIp,
+                         final Operation operation,
+                         final Resource resource,
+                         final boolean hasAccess) {
+        this.sourceIp = sourceIp;
         this.operation = operation;
         this.resource = resource;
         this.hasAccess = hasAccess;
@@ -55,4 +66,5 @@ public class UserOperation {
     public int hashCode() {
         return Objects.hash(operation, resource, hasAccess);
     }
+
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
@@ -16,6 +16,9 @@
 
 package io.aiven.kafka.auth.audit;
 
+import java.util.Objects;
+
+import kafka.network.RequestChannel;
 import kafka.security.auth.Operation;
 import kafka.security.auth.Resource;
 import org.slf4j.Logger;
@@ -23,6 +26,7 @@ import org.slf4j.Logger;
 public class UserOperationsActivityAuditor extends Auditor {
 
     public UserOperationsActivityAuditor() {
+        super();
     }
 
     protected UserOperationsActivityAuditor(final Logger logger) {
@@ -30,12 +34,56 @@ public class UserOperationsActivityAuditor extends Auditor {
     }
 
     @Override
-    protected UserActivity onUserActivity(final UserActivity userActivity,
-                                          final Operation operation,
-                                          final Resource resource,
-                                          final Boolean hasAccess) {
-        userActivity.addOperation(new UserOperation(operation, resource, hasAccess));
-        return userActivity;
+    protected void addActivity0(final RequestChannel.Session session,
+                                final Operation operation,
+                                final Resource resource,
+                                final boolean hasAccess) {
+        auditStorage.compute(createAuditKey(session), (key, userActivity) -> {
+            final UserActivity ua;
+            if (Objects.isNull(userActivity)) {
+                ua = createUserActivity();
+            } else {
+                ua = userActivity;
+            }
+            ua.addOperation(new UserOperation(session.clientAddress(), operation, resource, hasAccess));
+            return ua;
+        });
     }
 
+    private AuditKey createAuditKey(final RequestChannel.Session session) {
+        final var grouping = auditorConfig.getAggregationGrouping();
+        switch (grouping) {
+            case USER:
+                return new AuditKey(session.principal(), null);
+            case USER_AND_IP:
+                return new AuditKey(session.principal(), session.clientAddress());
+            default:
+                throw new IllegalArgumentException("Unknown aggregation grouping type: " + grouping);
+        }
+    }
+
+    private UserActivity createUserActivity() {
+        final var grouping = auditorConfig.getAggregationGrouping();
+        switch (grouping) {
+            case USER:
+                return new UserActivity.UserActivityOperationsGropedByIP();
+            case USER_AND_IP:
+                return new UserActivity.UserActivityOperations();
+            default:
+                throw new IllegalArgumentException("Unknown aggregation grouping type: " + grouping);
+        }
+    }
+
+    @Override
+    protected AuditorDumpFormatter createFormatter() {
+        final var grouping = auditorConfig.getAggregationGrouping();
+        switch (grouping) {
+            case USER:
+                return new PrincipalFormatter();
+            case USER_AND_IP:
+                return new PrincipalAndIpFormatter();
+            default:
+                throw new IllegalArgumentException("Unknown aggregation grouping type: " + grouping);
+        }
+    }
 }

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerConfigTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.auth.audit.NoAuditor;
 import io.aiven.kafka.auth.audit.UserActivityAuditor;
+import io.aiven.kafka.auth.audit.UserOperationsActivityAuditor;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,15 +49,27 @@ class AivenAclAuthorizerConfigTest {
 
     @Test
     void correctFullConfig() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("aiven.acl.authorizer.configuration", "/test");
-        properties.put("aiven.acl.authorizer.auditor.class.name", UserActivityAuditor.class.getName());
-        properties.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
-        properties.put("aiven.acl.authorizer.log.denials", "false");
+        final Map<String, String> userActivityProps = new HashMap<>();
+        userActivityProps.put("aiven.acl.authorizer.configuration", "/test");
+        userActivityProps.put("aiven.acl.authorizer.auditor.class.name", UserActivityAuditor.class.getName());
+        userActivityProps.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
+        userActivityProps.put("aiven.acl.authorizer.log.denials", "false");
 
-        final AivenAclAuthorizerConfig config = new AivenAclAuthorizerConfig(properties);
+        var config = new AivenAclAuthorizerConfig(userActivityProps);
         assertEquals("/test", config.getConfigFile().getAbsolutePath());
         assertEquals(UserActivityAuditor.class, config.getAuditor().getClass());
+        assertFalse(config.logDenials());
+
+        final Map<String, String> userActivityOpsProps = new HashMap<>();
+        userActivityOpsProps.put("aiven.acl.authorizer.configuration", "/test");
+        userActivityOpsProps.put("aiven.acl.authorizer.auditor.class.name",
+                UserOperationsActivityAuditor.class.getName());
+        userActivityOpsProps.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
+        userActivityOpsProps.put("aiven.acl.authorizer.log.denials", "false");
+
+        config = new AivenAclAuthorizerConfig(userActivityOpsProps);
+        assertEquals("/test", config.getConfigFile().getAbsolutePath());
+        assertEquals(UserOperationsActivityAuditor.class, config.getAuditor().getClass());
         assertFalse(config.logDenials());
     }
 

--- a/src/test/java/io/aiven/kafka/auth/audit/AuditorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/AuditorConfigTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AuditorConfigTest {
+
     @Test
     void correctMinimalConfig() {
         final Map<String, String> properties = new HashMap<>();
@@ -34,6 +35,20 @@ class AuditorConfigTest {
 
         final AuditorConfig config = new AuditorConfig(properties);
         assertEquals(123, config.getAggregationPeriodInSeconds());
+        assertEquals(AuditorConfig.AggregationGrouping.USER_AND_IP,
+                config.getAggregationGrouping());
+    }
+
+    @Test
+    void correctFullConfig() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("aiven.acl.authorizer.auditor.aggregation.period", "123");
+        properties.put("aiven.acl.authorizer.auditor.aggregation.grouping", "user");
+
+        final AuditorConfig config = new AuditorConfig(properties);
+        assertEquals(123, config.getAggregationPeriodInSeconds());
+        assertEquals(AuditorConfig.AggregationGrouping.USER,
+                config.getAggregationGrouping());
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
@@ -18,6 +18,8 @@ package io.aiven.kafka.auth.audit;
 
 import java.net.InetAddress;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,11 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link PrincipalAndIpFormatter}.
  */
 public class PrincipalAndIpFormatterTest extends FormatterTestBase {
+
+    public PrincipalAndIpFormatterTest() {
+        super(AuditorConfig.AggregationGrouping.USER_AND_IP);
+    }
+
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
@@ -74,4 +81,20 @@ public class PrincipalAndIpFormatterTest extends FormatterTestBase {
 
         twoOperationsTwoIpAddresses(now, expected1, expected2);
     }
+
+    protected void twoOperationsTwoIpAddresses(final ZonedDateTime now, final String... expected) {
+        final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
+
+        final UserActivity userActivity = createUserActivity(now);
+        userActivity.addOperation(new UserOperation(session.clientAddress(), operation, resource, false));
+        dump.put(createAuditKey(session), userActivity);
+
+        final UserActivity anotherUserActivity = createUserActivity(now);
+        anotherUserActivity.addOperation(
+                new UserOperation(anotherSession.clientAddress(), anotherOperation, anotherResource, true));
+        dump.put(createAuditKey(anotherSession), anotherUserActivity);
+
+        formatAndAssert(dump, expected);
+    }
+
 }


### PR DESCRIPTION
The first implementation was done not as it was expected to be.

The new configuration parameter  `aiven.acl.authorizer.auditor.aggregation.grouping` is applicable only for `UserOperationsActivityAuditor` which collects user operations. To collect operations groped by `user` or `principal`, it is enough to use `AuditorKey` with `principal` only and collect all user operations from different sessions in `UserActivity` and group them by IP address. For that `UserActivity` was split up into 2 subclasses:
1. `UserActivity.UserActivityOperations` - collects user and operations. this default behavior. All operations store in `LinkedHashMap` which helps to exclude additional operations for checking duplicates and keep operations order
2. `UserActivity.UserActivityOperationsGropedByIP` - collects user and its operations and group them by IP address. All operations store in `LinkedHashMap` which helps to exclude additional operations for checking duplicates, keep operations order, and group operations by IP address
As result, it is simplified formatting logic of log messages (no need to sort such messages)

Besides that `AggregationGrouping` constants were renamed to `user` and `user_and_ip` which is more convenient to existing naming.
