### PR TITLE
Fix hashCode/equals methods for UserActivity class

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivity.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.auth.audit;
 
 import java.net.InetAddress;
+import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -27,13 +28,16 @@ import java.util.function.BiFunction;
 
 abstract class UserActivity {
 
+    public final Principal principal;
+
     public final ZonedDateTime activeSince;
 
-    protected UserActivity() {
-        this(ZonedDateTime.now());
+    protected UserActivity(final Principal principal) {
+        this(principal, ZonedDateTime.now());
     }
 
-    protected UserActivity(final ZonedDateTime activeSince) {
+    protected UserActivity(final Principal principal, final ZonedDateTime activeSince) {
+        this.principal = principal;
         this.activeSince = activeSince;
     }
 
@@ -48,22 +52,22 @@ abstract class UserActivity {
             return false;
         }
         final UserActivity that = (UserActivity) o;
-        return Objects.equals(activeSince, that.activeSince);
+        return Objects.equals(principal, that.principal);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(activeSince);
+        return Objects.hash(principal);
     }
 
     static final class UserActivityOperations extends UserActivity {
 
-        public UserActivityOperations() {
-            super();
+        public UserActivityOperations(final Principal principal) {
+            super(principal);
         }
 
-        public UserActivityOperations(final ZonedDateTime activeSince) {
-            super(activeSince);
+        public UserActivityOperations(final Principal principal, final ZonedDateTime activeSince) {
+            super(principal, activeSince);
         }
 
         /**
@@ -80,12 +84,12 @@ abstract class UserActivity {
 
     static final class UserActivityOperationsGropedByIP extends UserActivity {
 
-        public UserActivityOperationsGropedByIP() {
-            super();
+        public UserActivityOperationsGropedByIP(final Principal principal) {
+            super(principal);
         }
 
-        public UserActivityOperationsGropedByIP(final ZonedDateTime activeSince) {
-            super(activeSince);
+        public UserActivityOperationsGropedByIP(final Principal principal, final ZonedDateTime activeSince) {
+            super(principal, activeSince);
         }
 
         public final Map<InetAddress, Set<UserOperation>> operations = new LinkedHashMap<>();

--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivityAuditor.java
@@ -53,7 +53,7 @@ public class UserActivityAuditor extends Auditor {
         final AuditKey auditKey = new AuditKey(session.principal(), session.clientAddress());
 
         auditStorage.compute(auditKey, (key, userActivity) -> Objects.isNull(userActivity)
-                ? new UserActivity.UserActivityOperations()
+                ? new UserActivity.UserActivityOperations(session.principal())
                 : userActivity
         );
     }

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.auth.audit;
 
+import java.security.Principal;
 import java.util.Objects;
 
 import kafka.network.RequestChannel;
@@ -41,7 +42,7 @@ public class UserOperationsActivityAuditor extends Auditor {
         auditStorage.compute(createAuditKey(session), (key, userActivity) -> {
             final UserActivity ua;
             if (Objects.isNull(userActivity)) {
-                ua = createUserActivity();
+                ua = createUserActivity(session.principal());
             } else {
                 ua = userActivity;
             }
@@ -62,13 +63,13 @@ public class UserOperationsActivityAuditor extends Auditor {
         }
     }
 
-    private UserActivity createUserActivity() {
+    private UserActivity createUserActivity(final Principal principal) {
         final var grouping = auditorConfig.getAggregationGrouping();
         switch (grouping) {
             case USER:
-                return new UserActivity.UserActivityOperationsGropedByIP();
+                return new UserActivity.UserActivityOperationsGropedByIP(principal);
             case USER_AND_IP:
-                return new UserActivity.UserActivityOperations();
+                return new UserActivity.UserActivityOperations(principal);
             default:
                 throw new IllegalArgumentException("Unknown aggregation grouping type: " + grouping);
         }

--- a/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
@@ -18,7 +18,6 @@ package io.aiven.kafka.auth.audit;
 
 import java.net.InetAddress;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +31,8 @@ import kafka.security.auth.Operation;
 import kafka.security.auth.Resource;
 import kafka.security.auth.ResourceType;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FormatterTestBase {
@@ -123,6 +124,6 @@ public class FormatterTestBase {
         final List<String> entries = formatter.format(dump);
 
         assertEquals(expected.length, entries.size());
-        assertEquals(Arrays.asList(expected), entries);
+        assertThat(entries, containsInAnyOrder(expected));
     }
 }

--- a/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
@@ -79,15 +79,16 @@ public class FormatterTestBase {
         );
     }
 
-    protected void zeroOperations(final ZonedDateTime now, final String expected) {
+    protected void zeroOperations(final RequestChannel.Session session,
+                                  final ZonedDateTime now, final String expected) {
         final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
-        dump.put(createAuditKey(session), createUserActivity(now));
+        dump.put(createAuditKey(session), createUserActivity(session, now));
         formatAndAssert(dump, expected);
     }
 
     protected void twoOperations(final ZonedDateTime now, final String expected) {
         final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
-        final UserActivity userActivity = createUserActivity(now);
+        final UserActivity userActivity = createUserActivity(session, now);
         userActivity.addOperation(new UserOperation(session.clientAddress(), operation, resource, false));
         userActivity.addOperation(
                 new UserOperation(session.clientAddress(), anotherOperation, anotherResource, true));
@@ -107,12 +108,12 @@ public class FormatterTestBase {
         }
     }
 
-    protected UserActivity createUserActivity(final ZonedDateTime time) {
+    protected UserActivity createUserActivity(final RequestChannel.Session session, final ZonedDateTime time) {
         switch (aggregationGrouping) {
             case USER:
-                return new UserActivity.UserActivityOperationsGropedByIP(time);
+                return new UserActivity.UserActivityOperationsGropedByIP(session.principal(), time);
             case USER_AND_IP:
-                return new UserActivity.UserActivityOperations(time);
+                return new UserActivity.UserActivityOperations(session.principal(), time);
             default:
                 throw new IllegalArgumentException("Unknown aggregation grouping: " + aggregationGrouping);
         }

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
@@ -47,7 +47,7 @@ public class PrincipalAndIpFormatterTest extends FormatterTestBase {
                 InetAddress.getLocalHost(),
                 now.format(AuditorDumpFormatter.dateFormatter())
         );
-        zeroOperations(now, expected);
+        zeroOperations(session, now, expected);
     }
 
     @Test
@@ -85,11 +85,11 @@ public class PrincipalAndIpFormatterTest extends FormatterTestBase {
     protected void twoOperationsTwoIpAddresses(final ZonedDateTime now, final String... expected) {
         final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
 
-        final UserActivity userActivity = createUserActivity(now);
+        final UserActivity userActivity = createUserActivity(session, now);
         userActivity.addOperation(new UserOperation(session.clientAddress(), operation, resource, false));
         dump.put(createAuditKey(session), userActivity);
 
-        final UserActivity anotherUserActivity = createUserActivity(now);
+        final UserActivity anotherUserActivity = createUserActivity(anotherSession, now);
         anotherUserActivity.addOperation(
                 new UserOperation(anotherSession.clientAddress(), anotherOperation, anotherResource, true));
         dump.put(createAuditKey(anotherSession), anotherUserActivity);

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalFormatterTest.java
@@ -42,7 +42,7 @@ public class PrincipalFormatterTest extends FormatterTestBase {
         final String expected = String.format(
                 "PRINCIPAL_TYPE:PRINCIPAL_NAME was active since %s.",
                 now.format(AuditorDumpFormatter.dateFormatter()));
-        zeroOperations(now, expected);
+        zeroOperations(session, now, expected);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class PrincipalFormatterTest extends FormatterTestBase {
     protected void twoOperationsTwoIpAddresses(final ZonedDateTime now, final String... expected) {
         final Map<Auditor.AuditKey, UserActivity> dump = new HashMap<>();
 
-        final UserActivity userActivity = createUserActivity(now);
+        final UserActivity userActivity = createUserActivity(session, now);
         userActivity.addOperation(
                 new UserOperation(session.clientAddress(), operation, resource, false));
         userActivity.addOperation(


### PR DESCRIPTION
The `UserActivity` class hashCode/equals methods use `activeSince` for
checking the equivalence of the object since `activeSince` always creates `hashCode/equals` do not work properly in such case.
I added `principal` and use it in `hashCode/equals` insetad of activeSince.