### PR TITLE
Get rid of the old auth API

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -16,4 +16,5 @@
     <suppress checks="NPathComplexity" files="AivenAclAuthorizer.java" />
     <suppress checks="MethodLength" files="AivenAclAuthorizerTest.java"/>
     <suppress checks="ClassFanOutComplexity" files="AivenAclAuthorizerV2Test.java"/>
+    <suppress checks="CyclomaticComplexity" files="LegacyOperationNameFormatter.java" />
 </suppressions>

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizer.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizer.java
@@ -135,7 +135,7 @@ public class AivenAclAuthorizer implements Authorizer {
                 operation.name(),
                 resourceToCheck
             );
-        auditor.addActivity(session, operation, resource, verdict);
+        auditor.addActivity(session, operation.toJava(), resource.toPattern(), verdict);
         return verdict;
     }
 

--- a/src/main/java/io/aiven/kafka/auth/audit/Auditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/Auditor.java
@@ -26,11 +26,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import kafka.network.RequestChannel.Session;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +68,8 @@ public abstract class Auditor implements AuditorAPI {
 
     @Override
     public final void addActivity(final Session session,
-                                  final Operation operation,
-                                  final Resource resource,
+                                  final AclOperation operation,
+                                  final ResourcePattern resource,
                                   final boolean hasAccess) {
         auditLock.lock();
         try {
@@ -80,8 +80,8 @@ public abstract class Auditor implements AuditorAPI {
     }
 
     protected abstract void addActivity0(final Session session,
-                                         final Operation operation,
-                                         final Resource resource,
+                                         final AclOperation operation,
+                                         final ResourcePattern resource,
                                          final boolean hasAccess);
 
     @Override

--- a/src/main/java/io/aiven/kafka/auth/audit/AuditorDumpFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/AuditorDumpFormatter.java
@@ -38,9 +38,8 @@ public interface AuditorDumpFormatter {
 
     default String formatUserOperation(final UserOperation userOperation) {
         return (userOperation.hasAccess ? "Allow" : "Deny")
-                + " " + userOperation.operation.name() + " on "
+                + " " + userOperation.operation + " on "
                 + userOperation.resource.resourceType() + ":"
                 + userOperation.resource.name();
     }
-
 }

--- a/src/main/java/io/aiven/kafka/auth/audit/NoAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/NoAuditor.java
@@ -18,9 +18,10 @@ package io.aiven.kafka.auth.audit;
 
 import java.util.Map;
 
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.ResourcePattern;
+
 import kafka.network.RequestChannel;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
 
 /**
  * A no-op {@link AuditorAPI}.
@@ -33,8 +34,8 @@ public class NoAuditor implements AuditorAPI {
 
     @Override
     public void addActivity(final RequestChannel.Session session,
-                            final Operation operation,
-                            final Resource resource,
+                            final AclOperation operation,
+                            final ResourcePattern resource,
                             final boolean hasAccess) {
     }
 

--- a/src/main/java/io/aiven/kafka/auth/audit/UserActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserActivityAuditor.java
@@ -19,11 +19,11 @@ package io.aiven.kafka.auth.audit;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.resource.ResourcePattern;
 
 import kafka.network.RequestChannel;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
 import org.slf4j.Logger;
 
 public class UserActivityAuditor extends Auditor {
@@ -47,8 +47,8 @@ public class UserActivityAuditor extends Auditor {
 
     @Override
     protected void addActivity0(final RequestChannel.Session session,
-                                final Operation operation,
-                                final Resource resource,
+                                final AclOperation operation,
+                                final ResourcePattern resource,
                                 final boolean hasAccess) {
         final AuditKey auditKey = new AuditKey(session.principal(), session.clientAddress());
 

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperation.java
@@ -19,28 +19,28 @@ package io.aiven.kafka.auth.audit;
 import java.net.InetAddress;
 import java.util.Objects;
 
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.ResourcePattern;
 
 public class UserOperation {
 
     public final InetAddress sourceIp;
 
-    public final Operation operation;
+    public final AclOperation operation;
 
-    public final Resource resource;
+    public final ResourcePattern resource;
 
     public final boolean hasAccess;
 
-    public UserOperation(final Operation operation,
-                         final Resource resource,
+    public UserOperation(final AclOperation operation,
+                         final ResourcePattern resource,
                          final boolean hasAccess) {
         this(null, operation, resource, hasAccess);
     }
 
     public UserOperation(final InetAddress sourceIp,
-                         final Operation operation,
-                         final Resource resource,
+                         final AclOperation operation,
+                         final ResourcePattern resource,
                          final boolean hasAccess) {
         this.sourceIp = sourceIp;
         this.operation = operation;

--- a/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
+++ b/src/main/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditor.java
@@ -18,9 +18,10 @@ package io.aiven.kafka.auth.audit;
 
 import java.util.Objects;
 
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.ResourcePattern;
+
 import kafka.network.RequestChannel;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
 import org.slf4j.Logger;
 
 public class UserOperationsActivityAuditor extends Auditor {
@@ -35,8 +36,8 @@ public class UserOperationsActivityAuditor extends Auditor {
 
     @Override
     protected void addActivity0(final RequestChannel.Session session,
-                                final Operation operation,
-                                final Resource resource,
+                                final AclOperation operation,
+                                final ResourcePattern resource,
                                 final boolean hasAccess) {
         auditStorage.compute(createAuditKey(session), (key, userActivity) -> {
             final UserActivity ua;

--- a/src/main/java/io/aiven/kafka/auth/nameformatters/LegacyNameFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nameformatters/LegacyNameFormatter.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.auth.audit;
+package io.aiven.kafka.auth.nameformatters;
 
-import org.apache.kafka.common.Configurable;
-import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.resource.ResourcePattern;
-
-import kafka.network.RequestChannel;
-
-public interface AuditorAPI extends Configurable {
-    void addActivity(final RequestChannel.Session session,
-                     final AclOperation operation,
-                     final ResourcePattern resource,
-                     final boolean hasAccess);
-
-    void stop();
+public final class LegacyNameFormatter {
+    /**
+     * Converts names like {@code DELEGATION_TOKEN} into {@code DelegationToken}.
+     */
+    static String format(final String name) {
+        final String[] parts = name.split("_");
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = parts[i].charAt(0) + parts[i].substring(1).toLowerCase();
+        }
+        return String.join("", parts);
+    }
 }

--- a/src/main/java/io/aiven/kafka/auth/nameformatters/LegacyOperationNameFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nameformatters/LegacyOperationNameFormatter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nameformatters;
+
+import org.apache.kafka.common.acl.AclOperation;
+
+public final class LegacyOperationNameFormatter {
+    public static String format(final AclOperation operation) {
+        switch (operation) {
+            case UNKNOWN:
+                return "Unknown";
+
+            case ANY:
+                return "Any";
+
+            case ALL:
+                return "All";
+
+            case READ:
+                return "Read";
+
+            case WRITE:
+                return "Write";
+
+            case CREATE:
+                return "Create";
+
+            case DELETE:
+                return "Delete";
+
+            case ALTER:
+                return "Alter";
+
+            case DESCRIBE:
+                return "Describe";
+
+            case CLUSTER_ACTION:
+                return "ClusterAction";
+
+            case DESCRIBE_CONFIGS:
+                return "DescribeConfigs";
+
+            case ALTER_CONFIGS:
+                return "AlterConfigs";
+
+            case IDEMPOTENT_WRITE:
+                return "IdempotentWrite";
+
+            default:
+                // In case there's an unknown operation, fall back to the slow path.
+                return LegacyNameFormatter.format(operation.name());
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/nameformatters/LegacyResourceTypeNameFormatter.java
+++ b/src/main/java/io/aiven/kafka/auth/nameformatters/LegacyResourceTypeNameFormatter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nameformatters;
+
+import org.apache.kafka.common.resource.ResourceType;
+
+public final class LegacyResourceTypeNameFormatter {
+    public static String format(final ResourceType resourceType) {
+        switch (resourceType) {
+            case UNKNOWN:
+                return "Unknown";
+
+            case ANY:
+                return "Any";
+
+            case TOPIC:
+                return "Topic";
+
+            case GROUP:
+                return "Group";
+
+            case CLUSTER:
+                return "Cluster";
+
+            case TRANSACTIONAL_ID:
+                return "TransactionalId";
+
+            case DELEGATION_TOKEN:
+                return "DelegationToken";
+
+            default:
+                // In case there's an unknown resource type, fall back to the slow path.
+                return LegacyNameFormatter.format(resourceType.name());
+        }
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/FormatterTestBase.java
@@ -26,12 +26,11 @@ import java.util.Map;
 
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import kafka.network.RequestChannel;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
-import kafka.security.auth.ResourceType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -39,15 +38,15 @@ public class FormatterTestBase {
 
     protected RequestChannel.Session session;
 
-    protected Operation operation;
+    protected AclOperation operation;
 
-    protected Resource resource;
+    protected ResourcePattern resource;
 
     protected AuditorDumpFormatter formatter;
 
-    protected Operation anotherOperation;
+    protected AclOperation anotherOperation;
 
-    protected Resource anotherResource;
+    protected ResourcePattern anotherResource;
 
     protected RequestChannel.Session anotherSession;
 
@@ -65,16 +64,16 @@ public class FormatterTestBase {
         anotherInetAddress = InetAddress.getByName("192.168.0.1");
         anotherSession = new RequestChannel.Session(principal, anotherInetAddress);
         resource =
-                new Resource(
-                        ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.CLUSTER),
+                new ResourcePattern(
+                        ResourceType.CLUSTER,
                         "resource",
                         PatternType.LITERAL
                 );
-        operation = Operation.fromJava(AclOperation.ALTER);
+        operation = AclOperation.ALTER;
 
-        anotherOperation = Operation.fromJava(AclOperation.ALTER);
-        anotherResource = new Resource(
-                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
+        anotherOperation = AclOperation.ALTER;
+        anotherResource = new ResourcePattern(
+                ResourceType.DELEGATION_TOKEN,
                 "ANOTHER_RESOURCE_NAME",
                 PatternType.LITERAL
         );

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalAndIpFormatterTest.java
@@ -55,8 +55,8 @@ public class PrincipalAndIpFormatterTest extends FormatterTestBase {
         final ZonedDateTime now = ZonedDateTime.now();
         final String expected = String.format(
                 "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: "
-                        + "Deny Alter on Cluster:resource, "
-                        + "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                        + "Deny ALTER on CLUSTER:resource, "
+                        + "Allow ALTER on DELEGATION_TOKEN:ANOTHER_RESOURCE_NAME",
                 InetAddress.getLocalHost(),
                 now.format(AuditorDumpFormatter.dateFormatter())
         );
@@ -68,13 +68,13 @@ public class PrincipalAndIpFormatterTest extends FormatterTestBase {
     public void shouldBuildRightLogMessageTwoOperationsTwoIps() throws Exception {
         final ZonedDateTime now = ZonedDateTime.now();
         final String expected1 = String.format(
-                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: Deny Alter on Cluster:resource",
+                "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: Deny ALTER on CLUSTER:resource",
                 InetAddress.getLocalHost(),
                 now.format(AuditorDumpFormatter.dateFormatter())
         );
         final String expected2 = String.format(
                 "PRINCIPAL_TYPE:PRINCIPAL_NAME (%s) was active since %s: "
-                        + "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                        + "Allow ALTER on DELEGATION_TOKEN:ANOTHER_RESOURCE_NAME",
                 anotherInetAddress,
                 now.format(AuditorDumpFormatter.dateFormatter())
         );

--- a/src/test/java/io/aiven/kafka/auth/audit/PrincipalFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/PrincipalFormatterTest.java
@@ -50,7 +50,7 @@ public class PrincipalFormatterTest extends FormatterTestBase {
         final ZonedDateTime now = ZonedDateTime.now();
         final String expected = String.format(
                 "PRINCIPAL_TYPE:PRINCIPAL_NAME was active since %s. %s: "
-                        + "Deny Alter on Cluster:resource, Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                        + "Deny ALTER on CLUSTER:resource, Allow ALTER on DELEGATION_TOKEN:ANOTHER_RESOURCE_NAME",
                 now.format(AuditorDumpFormatter.dateFormatter()),
                 InetAddress.getLocalHost()
         );
@@ -63,8 +63,8 @@ public class PrincipalFormatterTest extends FormatterTestBase {
         final ZonedDateTime now = ZonedDateTime.now();
         final String expected = String.format(
                 "PRINCIPAL_TYPE:PRINCIPAL_NAME was active since %s. "
-                        + "%s: Deny Alter on Cluster:resource, "
-                        + "%s: Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME",
+                        + "%s: Deny ALTER on CLUSTER:resource, "
+                        + "%s: Allow ALTER on DELEGATION_TOKEN:ANOTHER_RESOURCE_NAME",
                 now.format(AuditorDumpFormatter.dateFormatter()),
                 InetAddress.getLocalHost(),
                 anotherInetAddress

--- a/src/test/java/io/aiven/kafka/auth/audit/UserActivityAuditorTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/UserActivityAuditorTest.java
@@ -25,12 +25,11 @@ import java.util.Map;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import kafka.network.RequestChannel.Session;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
-import kafka.security.auth.ResourceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,8 +51,8 @@ class UserActivityAuditorTest {
     private Logger logger;
 
     private Session session;
-    private Operation operation;
-    private Resource resource;
+    private AclOperation operation;
+    private ResourcePattern resource;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -61,12 +60,12 @@ class UserActivityAuditorTest {
                 new KafkaPrincipal("PRINCIPAL_TYPE", "PRINCIPAL_NAME");
         session = new Session(principal, InetAddress.getLocalHost());
         resource =
-            new Resource(
-                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.CLUSTER),
+            new ResourcePattern(
+                ResourceType.CLUSTER,
                 "resource",
                 PatternType.LITERAL
             );
-        operation = Operation.fromJava(AclOperation.ALTER);
+        operation = AclOperation.ALTER;
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditorTest.java
+++ b/src/test/java/io/aiven/kafka/auth/audit/UserOperationsActivityAuditorTest.java
@@ -27,12 +27,11 @@ import java.util.stream.Collectors;
 
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import kafka.network.RequestChannel.Session;
-import kafka.security.auth.Operation;
-import kafka.security.auth.Resource;
-import kafka.security.auth.ResourceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,19 +57,19 @@ class UserOperationsActivityAuditorTest {
 
     private KafkaPrincipal principal;
 
-    private Operation operation;
+    private AclOperation operation;
 
-    private Resource resource;
+    private ResourcePattern resource;
 
     @BeforeEach
     void setUp() throws Exception {
         principal = new KafkaPrincipal("PRINCIPAL_TYPE", "PRINCIPAL_NAME");
         session = new Session(principal, InetAddress.getLocalHost());
 
-        operation = Operation.fromJava(AclOperation.ALL);
+        operation = AclOperation.ALL;
         resource =
-                new Resource(
-                        ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.CLUSTER),
+                new ResourcePattern(
+                        ResourceType.CLUSTER,
                         "RESOURCE_NAME",
                         PatternType.LITERAL
                 );
@@ -168,9 +167,9 @@ class UserOperationsActivityAuditorTest {
     @Test
     public void shouldBuildRightLogMessage() throws Exception {
         final UserOperationsActivityAuditor auditor = createAuditor();
-        final Operation anotherOperation = Operation.fromJava(AclOperation.ALTER);
-        final Resource anotherResource = new Resource(
-                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
+        final AclOperation anotherOperation = AclOperation.ALTER;
+        final ResourcePattern anotherResource = new ResourcePattern(
+                ResourceType.DELEGATION_TOKEN,
                 "ANOTHER_RESOURCE_NAME",
                 PatternType.LITERAL
         );
@@ -206,8 +205,8 @@ class UserOperationsActivityAuditorTest {
         assertThat(
                 loggedOperations,
                 containsInAnyOrder(
-                        "Deny All on Cluster:RESOURCE_NAME",
-                        "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME"
+                        "Deny ALL on CLUSTER:RESOURCE_NAME",
+                        "Allow ALTER on DELEGATION_TOKEN:ANOTHER_RESOURCE_NAME"
                 )
         );
     }
@@ -220,9 +219,9 @@ class UserOperationsActivityAuditorTest {
                         10L,
                         AuditorConfig.AGGREGATION_GROUPING_CONF,
                         AuditorConfig.AggregationGrouping.USER.getConfigValue()));
-        final Operation anotherOperation = Operation.fromJava(AclOperation.ALTER);
-        final Resource anotherResource = new Resource(
-                ResourceType.fromJava(org.apache.kafka.common.resource.ResourceType.DELEGATION_TOKEN),
+        final AclOperation anotherOperation = AclOperation.ALTER;
+        final ResourcePattern anotherResource = new ResourcePattern(
+                ResourceType.DELEGATION_TOKEN,
                 "ANOTHER_RESOURCE_NAME",
                 PatternType.LITERAL
         );
@@ -255,8 +254,8 @@ class UserOperationsActivityAuditorTest {
         assertThat(
                 loggedOperations,
                 containsInAnyOrder(
-                        "Deny All on Cluster:RESOURCE_NAME",
-                        "Allow Alter on DelegationToken:ANOTHER_RESOURCE_NAME")
+                        "Deny ALL on CLUSTER:RESOURCE_NAME",
+                        "Allow ALTER on DELEGATION_TOKEN:ANOTHER_RESOURCE_NAME")
         );
     }
 

--- a/src/test/java/io/aiven/kafka/auth/nameformatters/LegacyOperationNameFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nameformatters/LegacyOperationNameFormatterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nameformatters;
+
+import org.apache.kafka.common.acl.AclOperation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LegacyOperationNameFormatterTest {
+    @Test
+    void testFormatting() {
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.UNKNOWN)).isEqualTo("Unknown");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.ANY)).isEqualTo("Any");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.ALL)).isEqualTo("All");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.READ)).isEqualTo("Read");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.WRITE)).isEqualTo("Write");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.CREATE)).isEqualTo("Create");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.DELETE)).isEqualTo("Delete");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.ALTER)).isEqualTo("Alter");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.DESCRIBE)).isEqualTo("Describe");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.CLUSTER_ACTION)).isEqualTo("ClusterAction");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.DESCRIBE_CONFIGS)).isEqualTo("DescribeConfigs");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.ALTER_CONFIGS)).isEqualTo("AlterConfigs");
+        assertThat(LegacyOperationNameFormatter.format(AclOperation.IDEMPOTENT_WRITE)).isEqualTo("IdempotentWrite");
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/nameformatters/LegacyResourceTypeNameFormatterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nameformatters/LegacyResourceTypeNameFormatterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.nameformatters;
+
+import org.apache.kafka.common.resource.ResourceType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LegacyResourceTypeNameFormatterTest {
+    @Test
+    void testFormatting() {
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.UNKNOWN)).isEqualTo("Unknown");
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.ANY)).isEqualTo("Any");
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.TOPIC)).isEqualTo("Topic");
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.GROUP)).isEqualTo("Group");
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.CLUSTER)).isEqualTo("Cluster");
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.TRANSACTIONAL_ID)).isEqualTo("TransactionalId");
+        assertThat(LegacyResourceTypeNameFormatter.format(ResourceType.DELEGATION_TOKEN)).isEqualTo("DelegationToken");
+    }
+}


### PR DESCRIPTION
Remove as much of the old auth API as possible. `AivenAclAuthorizer` is the only direct dependent now.

The only visible change is the operation and resource type names in the logs: `ALTER` instead of `Alter`, `DELEGATION_TOKEN` instead of `DelegationToken`, etc.