### PR TITLE
Add AivenKafkaPrincipalBuilderV2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ jmh {
 }
 
 ext {
-    kafkaVersion = "2.4.0"
+    kafkaVersion = "2.8.0"
 }
 
 dependencies {

--- a/src/main/java/io/aiven/kafka/auth/AivenKafkaPrincipalBuilderV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenKafkaPrincipalBuilderV2.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.KafkaPrincipalSerde;
+import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
+
+import io.aiven.kafka.auth.utils.TimeWithTimer;
+
+public class AivenKafkaPrincipalBuilderV2 extends AivenKafkaPrincipalBuilder implements KafkaPrincipalSerde {
+    private static final DefaultKafkaPrincipalBuilder DEFAULT_KAFKA_PRINCIPAL_BUILDER =
+        new DefaultKafkaPrincipalBuilder(null, null);
+
+    public AivenKafkaPrincipalBuilderV2() {
+        super();
+    }
+
+    public AivenKafkaPrincipalBuilderV2(final TimeWithTimer time) {
+        super(time);
+    }
+
+    @Override
+    public byte[] serialize(final KafkaPrincipal principal) {
+        return DEFAULT_KAFKA_PRINCIPAL_BUILDER.serialize(principal);
+    }
+
+    @Override
+    public KafkaPrincipal deserialize(final byte[] bytes) {
+        return DEFAULT_KAFKA_PRINCIPAL_BUILDER.deserialize(bytes);
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerV2Test.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerV2Test.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.network.ClientInformation;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.RequestContext;
@@ -235,7 +236,9 @@ public class AivenAclAuthorizerV2Test {
             InetAddress.getLoopbackAddress(),
             new KafkaPrincipal(principalType, name),
             new ListenerName("SSL"),
-            SecurityProtocol.SSL
+            SecurityProtocol.SSL,
+            ClientInformation.EMPTY,
+            false
         );
     }
 

--- a/src/test/java/io/aiven/kafka/auth/AivenKafkaPrincipalBuilderV2SerializationTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenKafkaPrincipalBuilderV2SerializationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AivenKafkaPrincipalBuilderV2SerializationTest {
+    private AivenKafkaPrincipalBuilderV2 builder;
+
+    @BeforeEach
+    public void initTests() {
+        builder = new AivenKafkaPrincipalBuilderV2(null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("principalProvider")
+    public void testSerialization(final KafkaPrincipal principal) {
+        final byte[] serializedPrincipal = builder.serialize(principal);
+        final KafkaPrincipal deserializedPrincipal = builder.deserialize(serializedPrincipal);
+        assertThat(deserializedPrincipal).isEqualTo(principal);
+    }
+
+    private static Stream<KafkaPrincipal> principalProvider() {
+        return Stream.of(
+            new KafkaPrincipal("some type", "some name", true),
+            KafkaPrincipal.ANONYMOUS
+        );
+    }
+}


### PR DESCRIPTION
This implements `KafkaPrincipalSerde`, which is needed for Kafka 3.0.

A separate class (from `AivenKafkaPrincipalBuilder`) is needed to keep a builder available for per-2.8 Kafkas, where there is no `KafkaPrincipalSerde` interface.

The dependency needed to be updated to Kafka 2.8, as it supports `KafkaPrincipalSerde` interface, which is required for `AivenKafkaPrincipalBuilder` in Kafka 3.0.